### PR TITLE
[bugfix/SignUp,SignIn] 유저 데이터가 안뜨는 버그 수정

### DIFF
--- a/src/services/auth-services.ts
+++ b/src/services/auth-services.ts
@@ -1,5 +1,5 @@
 import { FieldValues } from "react-hook-form";
-import supabase from "./supabase";
+import supabase from "./supabase-client";
 
 export const signUp = async (data: FieldValues) => {
   const { email, password, nickname } = data;

--- a/src/services/home-services.ts
+++ b/src/services/home-services.ts
@@ -1,4 +1,4 @@
-import supabase from "./supabase";
+import supabase from "./supabase-client";
 
 export const getPostEmotionByUserId = async () => {
   // 유저 정보 가져와서 비교할 예정

--- a/src/services/supabase-client.ts
+++ b/src/services/supabase-client.ts
@@ -2,9 +2,9 @@ import ENV from "@/constants/env";
 import { createBrowserClient } from "@supabase/ssr";
 
 // 클라이언트 전용 supabase
-const supabase = createBrowserClient(
+const supabaseClient = createBrowserClient(
   ENV.SUPABASE_URL_CLIENT!,
   ENV.SUPABASE_ANON_KEY_CLIENT!,
 );
 
-export default supabase;
+export default supabaseClient;

--- a/src/services/supabase-client.ts
+++ b/src/services/supabase-client.ts
@@ -1,9 +1,10 @@
 import ENV from "@/constants/env";
 import { createBrowserClient } from "@supabase/ssr";
 
+// 클라이언트 전용 supabase
 const supabase = createBrowserClient(
-  ENV.SUPABASE_URL_CLIENT,
-  ENV.SUPABASE_ANON_KEY_CLIENT,
+  ENV.SUPABASE_URL_CLIENT!,
+  ENV.SUPABASE_ANON_KEY_CLIENT!,
 );
 
 export default supabase;

--- a/src/services/supabase-server.ts
+++ b/src/services/supabase-server.ts
@@ -2,9 +2,9 @@ import ENV from "@/constants/env";
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-function supabase() {
+// 서버 전용 supabase
+const supabaseServer = () => {
   const cookieStore = cookies();
-
   return createServerClient(
     ENV.SUPABASE_URL_SERVER!,
     ENV.SUPABASE_ANON_KEY_SERVER!,
@@ -21,6 +21,6 @@ function supabase() {
       },
     },
   );
-}
+};
 
-export default supabase;
+export default supabaseServer;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Ref #10

<br>

## 📝 작업 내용

getUser()를 사용했을 때 유저 데이터가 null로 뜨는 버그를 수정했습니다.

<br>

![image](https://github.com/user-attachments/assets/d1b96c86-42e8-486a-87ca-ec2b51ba7380)

<br>

## 💬리뷰 요구사항

next/headers에서 불러오는 cookies는 Server Component 에서만 쓸 수 있는데, 클라이언트와 서버를 같은 파일에 두면 cookies가 클라이언트에서 import 되어있어서 문제가 생긴다고 합니다.

getUser를 쓸라면 
```
import supabaseServer from "./supabase-server";

const supabase = supabaseServer()
const { data: { user } } = await supabase.auth.getUser()
```
로 쓰는걸 추천드립니다. 
클라이언트 컴포넌트에서 쓰인다면 supabase-client 파일에서 import 해오시면 됩니다

supabase-server.ts 파일에서 const supabase = supabaseServer() 를 합치지 못한 이유는 Next.js의 cookies가 요청이 있을 때만 동작하기 때문입니다.
그래서 사용하는 쪽에서 직접 호출해야 한다고 합니다.

