### PR TITLE
[Feature/Music] 감정에 어울리는 트랙 리스트 출력 기능 추가 #4

### DIFF
--- a/src/app/music/components/music-api.ts
+++ b/src/app/music/components/music-api.ts
@@ -1,0 +1,56 @@
+import { Emotion } from "@/constants/spotify";
+import { EmotionKeywords } from "@/utils/music-emotion.util";
+import { AccessToken, TrackItem } from "../type";
+
+// Access Token 발급
+export const getAccessToken = async () => {
+  try {
+    const response = await fetch("/api/spotify/token");
+
+    if (!response.ok) {
+      console.error("AccessToken 요청 실패");
+      return null;
+    }
+
+    const data: AccessToken = await response.json();
+
+    return data.access_token;
+  } catch (error) {
+    console.error("AccessToken 예외 발생 : ", error);
+    return null;
+  }
+};
+
+// 감정 키워드로 직접 트랙(노래) 검색
+export const getTracksByEmotion = async (
+  emotion: Emotion,
+  accessToken: string,
+) => {
+  const searchKeyword = EmotionKeywords[emotion] ?? emotion.toString();
+
+  try {
+    const response = await fetch(
+      `https://api.spotify.com/v1/search?q=${encodeURIComponent(
+        searchKeyword,
+      )}&type=track&limit=30&market=KR`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      console.error("트랙 검색 실패");
+      return [];
+    }
+
+    const data = await response.json();
+    const tracks: TrackItem[] = data.tracks.items;
+
+    return tracks;
+  } catch (err) {
+    console.error("트랙 검색 중 예외 발생 : ", err);
+    return [];
+  }
+};

--- a/src/app/music/components/music-spotify.tsx
+++ b/src/app/music/components/music-spotify.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { getAccessToken, getTracksByEmotion } from "./music-api";
+import { Emotion } from "@/constants/spotify";
+import { useEffect, useState } from "react";
+import { TrackItem } from "../type";
+
+const MusicSpotify = () => {
+  const [tracks, setTracks] = useState<TrackItem[]>([]);
+  const emotion: Emotion = Emotion.HAPPY;
+
+  useEffect(() => {
+    const fetchTracks = async () => {
+      const accessToken = await getAccessToken();
+
+      if (!accessToken) return;
+
+      const result = await getTracksByEmotion(emotion, accessToken);
+      setTracks(result);
+    };
+
+    fetchTracks();
+  }, [emotion]);
+
+  return (
+    <div>
+      <h2>감정 기반 추천 노래 리스트 ({emotion})</h2>
+      <ul>
+        {tracks.map((track) => (
+          <li key={track.id}>
+            <p>
+              {track.name} - {track.artists[0]?.name}
+            </p>
+            <audio controls src={track.preview_url}></audio>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MusicSpotify;

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,5 +1,11 @@
+import MusicSpotify from "./components/music-spotify";
+
 const Music = () => {
-  return <div>Music</div>;
+  return (
+    <div>
+      <MusicSpotify />
+    </div>
+  );
 };
 
 export default Music;

--- a/src/app/music/type.ts
+++ b/src/app/music/type.ts
@@ -1,0 +1,30 @@
+export interface AccessToken {
+  access_token: string;
+}
+
+export interface Image {
+  url: string;
+}
+
+export interface Owner {
+  display_name: string;
+}
+
+export interface PlaylistItem {
+  id: string;
+  name: string;
+  images: Image[];
+  owner: Owner;
+}
+
+export interface PlaylistsResponse {
+  playlists: {
+    href: string;
+    items: PlaylistItem[];
+    limit: number;
+    next: string | null;
+    offset: number;
+    previous: string | null;
+    total: number;
+  };
+}

--- a/src/app/music/type.ts
+++ b/src/app/music/type.ts
@@ -2,29 +2,9 @@ export interface AccessToken {
   access_token: string;
 }
 
-export interface Image {
-  url: string;
-}
-
-export interface Owner {
-  display_name: string;
-}
-
-export interface PlaylistItem {
+export interface TrackItem {
   id: string;
   name: string;
-  images: Image[];
-  owner: Owner;
-}
-
-export interface PlaylistsResponse {
-  playlists: {
-    href: string;
-    items: PlaylistItem[];
-    limit: number;
-    next: string | null;
-    offset: number;
-    previous: string | null;
-    total: number;
-  };
+  preview_url: string;
+  artists: { name: string }[];
 }

--- a/src/constants/spotify.ts
+++ b/src/constants/spotify.ts
@@ -8,3 +8,11 @@ export const SPOTIFY = {
   REFRESH_TOKEN: "spotify_refresh_token",
   PRODUCTION: "production",
 };
+
+export enum Emotion {
+  HAPPY = "happy",
+  SAD = "sad",
+  FOCUS = "focus",
+  ENERGETIC = "energetic",
+  RELAX = "relax",
+}

--- a/src/utils/music-emotion.util.ts
+++ b/src/utils/music-emotion.util.ts
@@ -1,0 +1,9 @@
+import { Emotion } from "@/constants/spotify";
+
+export const EmotionKeywords: Record<Emotion, string> = {
+  [Emotion.HAPPY]: "happy",
+  [Emotion.SAD]: "sad",
+  [Emotion.FOCUS]: "focus",
+  [Emotion.ENERGETIC]: "energetic",
+  [Emotion.RELAX]: "relax",
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #4

<br>

## 📝 작업 내용

> 감정 키워드를 기반으로 Spotify에서 트랙(노래) 목록을 검색하여 출력하는 기능 구현

> getTracksByEmotion 함수로 감정 키워드를 활용해 곡 리스트만 추출

> 더 이상 사용하지 않는 플레이리스트 관련 함수 및 타입 제거

<br>

## 🖼 스크린샷

>  임시 감정 : happy, sad, focus, energetic, relax

<img width="1440" alt="스크린샷 2025-04-07 17 14 38" src="https://github.com/user-attachments/assets/5c201a23-5eb5-4691-b846-1cc9e3dc0420" />

<img width="1440" alt="스크린샷 2025-04-07 17 15 14" src="https://github.com/user-attachments/assets/d236e970-da07-443b-9088-24dfa9b8fb2c" />

<br>

## 💬 리뷰 요구사항

> 변수명과 파일 위치를 꼼꼼하게 확인해주세요 !! 변경사항이 있으면 즉시 반영하겠습니다 !!
