### PR TITLE
[Feature/m client] 감정 선택 드롭다운 리팩토링

### DIFF
--- a/src/app/api/spotify/callback/route.ts
+++ b/src/app/api/spotify/callback/route.ts
@@ -3,64 +3,78 @@ import { TOAST_MESSAGE } from "@/constants/toast-message.constant";
 import { NextRequest, NextResponse } from "next/server";
 
 export const GET = async (req: NextRequest) => {
-  // ① Spotify 자격 증명
-  const clientId = process.env.SPOTIFY_CLIENT_ID;
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  try {
+    // ① Spotify 자격 증명
+    const clientId = process.env.SPOTIFY_CLIENT_ID;
+    const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
 
-  if (!clientId || !clientSecret) {
-    return new NextResponse(TOAST_MESSAGE.SPOTIFY.CLIENT_ERROR, {
-      status: 500,
-    });
-  }
+    if (!clientId || !clientSecret) {
+      return new NextResponse(TOAST_MESSAGE.SPOTIFY.CLIENT_ERROR, {
+        status: 500,
+      });
+    }
 
-  // ② 토큰 발급 요청
-  const tokenEndpoint = SPOTIFY.TOKEN_ENDPOINT;
-  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
-    "base64",
-  );
+    // ② 토큰 발급 요청
+    const tokenEndpoint = SPOTIFY.TOKEN_ENDPOINT;
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+      "base64",
+    );
 
-  const tokenResponse = await fetch(tokenEndpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": SPOTIFY.CONTENT_TYPE,
-      Authorization: `Basic ${credentials}`,
-    },
-    body: new URLSearchParams({ grant_type: SPOTIFY.CLIENT_CREDENTIALS }),
-  });
-
-  // ③ 토큰 요청 실패 처리
-  if (!tokenResponse.ok) {
-    return new NextResponse(TOAST_MESSAGE.SPOTIFY.ACCESS_TOKEN_ERROR, {
-      status: 500,
-    });
-  }
-
-  const tokenData = await tokenResponse.json();
-  const accessToken = tokenData.access_token;
-  const expiresIn = tokenData.expires_in;
-
-  // ④ 토큰 쿠키 저장
-  const response = new NextResponse(
-    JSON.stringify({
-      accessToken: accessToken,
-      expiresIn,
-      success: true,
-    }),
-    {
-      status: 200,
+    const tokenResponse = await fetch(tokenEndpoint, {
+      method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": SPOTIFY.CONTENT_TYPE,
+        Authorization: `Basic ${credentials}`,
       },
-    },
-  );
+      body: new URLSearchParams({ grant_type: SPOTIFY.CLIENT_CREDENTIALS }),
+    });
 
-  response.cookies.set(SPOTIFY.ACCESS_TOKEN, accessToken, {
-    httpOnly: false, // 클라이언트 접근 허용 (보안 고려)
-    secure: process.env.NODE_ENV === SPOTIFY.PRODUCTION,
-    maxAge: expiresIn,
-    path: "/",
-    sameSite: "lax",
-  });
+    // ③ 토큰 요청 실패 처리
+    if (!tokenResponse.ok) {
+      const errorData = await tokenResponse.json();
+      const errorMessage =
+        errorData?.error_description ||
+        errorData?.error ||
+        TOAST_MESSAGE.SPOTIFY.CLIENT_ERROR;
 
-  return response;
+      return new NextResponse(errorMessage, { status: tokenResponse.status });
+    }
+
+    const tokenData = await tokenResponse.json();
+    const accessToken = tokenData.access_token;
+    const expiresIn = tokenData.expires_in;
+
+    // ④ 토큰 쿠키 저장
+    const response = new NextResponse(
+      JSON.stringify({
+        accessToken: accessToken,
+        expiresIn,
+        success: true,
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    response.cookies.set(SPOTIFY.ACCESS_TOKEN, accessToken, {
+      httpOnly: false, // 클라이언트 접근 허용
+      secure: process.env.NODE_ENV === SPOTIFY.PRODUCTION,
+      maxAge: expiresIn,
+      path: "/",
+      sameSite: "lax",
+    });
+
+    return response;
+  } catch (error: unknown) {
+    let errorMessage = TOAST_MESSAGE.SPOTIFY.CLIENT_ERROR;
+
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+
+    return new NextResponse(errorMessage, { status: 500 });
+  }
 };

--- a/src/app/api/spotify/callback/route.ts
+++ b/src/app/api/spotify/callback/route.ts
@@ -4,34 +4,39 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const GET = async (req: NextRequest) => {
   try {
-    // ① Spotify 자격 증명
+    // Spotify 자격 증명 가져오기
     const clientId = process.env.SPOTIFY_CLIENT_ID;
     const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
 
+    // 클라이언트 ID 또는 시크릿이 없으면 에러 응답 반환
     if (!clientId || !clientSecret) {
       return new NextResponse(TOAST_MESSAGE.SPOTIFY.CLIENT_ERROR, {
         status: 500,
       });
     }
 
-    // ② 토큰 발급 요청
+    // 토큰 발급을 위한 기본 정보 준비
     const tokenEndpoint = SPOTIFY.TOKEN_ENDPOINT;
+
+    // client_id:client_secret 형태를 base64로 인코딩 → Authorization 헤더용
     const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
       "base64",
     );
 
+    // access_token 요청 (Client Credentials 방식)
     const tokenResponse = await fetch(tokenEndpoint, {
       method: "POST",
       headers: {
         "Content-Type": SPOTIFY.CONTENT_TYPE,
-        Authorization: `Basic ${credentials}`,
+        Authorization: `Basic ${credentials}`, // Base64 인코딩된 자격 증명 사용
       },
       body: new URLSearchParams({ grant_type: SPOTIFY.CLIENT_CREDENTIALS }),
     });
 
-    // ③ 토큰 요청 실패 처리
+    // 요청 실패 시 에러 처리
     if (!tokenResponse.ok) {
       const errorData = await tokenResponse.json();
+
       const errorMessage =
         errorData?.error_description ||
         errorData?.error ||
@@ -40,17 +45,14 @@ export const GET = async (req: NextRequest) => {
       return new NextResponse(errorMessage, { status: tokenResponse.status });
     }
 
+    // access_token과 만료 시간 정보 추출
     const tokenData = await tokenResponse.json();
-    const accessToken = tokenData.access_token;
-    const expiresIn = tokenData.expires_in;
 
-    // ④ 토큰 쿠키 저장
+    const { access_token: accessToken, expires_in: expiresIn } = tokenData;
+
+    // access_token 반환 + 쿠키 저장
     const response = new NextResponse(
-      JSON.stringify({
-        accessToken: accessToken,
-        expiresIn,
-        success: true,
-      }),
+      JSON.stringify({ accessToken, expiresIn, success: true }),
       {
         status: 200,
         headers: {
@@ -59,16 +61,18 @@ export const GET = async (req: NextRequest) => {
       },
     );
 
+    // 토큰 쿠키 저장
     response.cookies.set(SPOTIFY.ACCESS_TOKEN, accessToken, {
-      httpOnly: false, // 클라이언트 접근 허용
+      httpOnly: false, // 클라이언트에서도 읽을 수 있도록 설정
       secure: process.env.NODE_ENV === SPOTIFY.PRODUCTION,
-      maxAge: expiresIn,
+      maxAge: expiresIn, // 기본 1시간
       path: "/",
       sameSite: "lax",
     });
 
     return response;
   } catch (error: unknown) {
+    // 에러 발생 시 응답 반환
     let errorMessage = TOAST_MESSAGE.SPOTIFY.CLIENT_ERROR;
 
     if (error instanceof Error) {

--- a/src/app/music/_components/emotion-select.tsx
+++ b/src/app/music/_components/emotion-select.tsx
@@ -1,0 +1,26 @@
+import { Emotion, EMOTION_DISPLAY_NAME } from "@/constants/spotify.constant";
+
+interface EmotionSelectProps {
+  value: Emotion;
+  onChange: (value: Emotion) => void;
+}
+
+const EmotionSelect = ({ value, onChange }: EmotionSelectProps) => {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as Emotion)}
+      className="p-2 border rounded mt-4 cursor-pointer"
+    >
+      {Object.entries(EMOTION_DISPLAY_NAME).map(
+        ([emotionKey, emotionDisplayName]) => (
+          <option key={emotionKey} value={emotionKey}>
+            {emotionDisplayName}
+          </option>
+        ),
+      )}
+    </select>
+  );
+};
+
+export default EmotionSelect;

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,23 +1,29 @@
 "use client";
 
-import { useState } from "react";
-import Image from "next/image";
-import { useGetAllPlaylistsByQueryQuery } from "@/hooks/queries/use-get-all-playlists-by-query-query";
-import { Emotion, EMOTION_DISPLAY_NAME } from "@/constants/spotify.constant";
-import { TOAST_MESSAGE } from "@/constants/toast-message.constant";
 import { QUERYDATA } from "@/constants/query-data.constant";
+import { Emotion } from "@/constants/spotify.constant";
+import { TOAST_MESSAGE } from "@/constants/toast-message.constant";
+import { useGetAllPlaylistsByQueryQuery } from "@/hooks/queries/use-get-all-playlists-by-query-query";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import EmotionSelect from "./_components/emotion-select";
 
 const Music = () => {
   const [query, setQuery] = useState(Emotion.JOY);
-  const { playlists, tokenPending, playlistsPending, playlistsError } =
+  const { playlists, playlistsPending, playlistsError } =
     useGetAllPlaylistsByQueryQuery(query);
 
-  if (tokenPending || playlistsPending) {
-    return QUERYDATA.ISPENDING;
-  }
+  useEffect(() => {
+    if (playlistsError) {
+      toast.warning(
+        playlistsError.message || TOAST_MESSAGE.SPOTIFY.PLAYLISTS_ERROR,
+      );
+    }
+  }, [playlistsError]);
 
-  if (playlistsError) {
-    return QUERYDATA.ISERROR;
+  if (playlistsPending) {
+    return QUERYDATA.ISPENDING;
   }
 
   if (!playlists || playlists.length === 0) {
@@ -27,30 +33,7 @@ const Music = () => {
   return (
     <div>
       <div className="mb-4">
-        <select
-          value={query}
-          onChange={(e) => setQuery(e.target.value as Emotion)}
-          className="p-2 border rounded mt-4"
-        >
-          <option value={Emotion.JOY}>{EMOTION_DISPLAY_NAME.JOY}</option>
-          <option value={Emotion.EXCITED}>
-            {EMOTION_DISPLAY_NAME.EXCITED}
-          </option>
-          <option value={Emotion.BUTTERFLY}>
-            {EMOTION_DISPLAY_NAME.BUTTERFLY}
-          </option>
-          <option value={Emotion.GRATEFUL}>
-            {EMOTION_DISPLAY_NAME.GRATEFUL}
-          </option>
-          <option value={Emotion.CALM}>{EMOTION_DISPLAY_NAME.CALM}</option>
-          <option value={Emotion.LONELY}>{EMOTION_DISPLAY_NAME.LONELY}</option>
-          <option value={Emotion.ANXIOUS}>
-            {EMOTION_DISPLAY_NAME.ANXIOUS}
-          </option>
-          <option value={Emotion.TIRED}>{EMOTION_DISPLAY_NAME.TIRED}</option>
-          <option value={Emotion.SAD}>{EMOTION_DISPLAY_NAME.SAD}</option>
-          <option value={Emotion.ANGRY}>{EMOTION_DISPLAY_NAME.ANGRY}</option>
-        </select>
+        <EmotionSelect value={query} onChange={setQuery} />
       </div>
       <ul>
         {playlists.map((playlist) => (

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -3,12 +3,12 @@
 import { useState } from "react";
 import Image from "next/image";
 import { useGetAllPlaylistsByQueryQuery } from "@/hooks/queries/use-get-all-playlists-by-query-query";
-import { Emotion } from "@/constants/spotify.constant";
+import { Emotion, EMOTION_DISPLAY_NAME } from "@/constants/spotify.constant";
 import { TOAST_MESSAGE } from "@/constants/toast-message.constant";
 import { QUERYDATA } from "@/constants/query-data.constant";
 
 const Music = () => {
-  const [query, setquery] = useState("happy");
+  const [query, setQuery] = useState(Emotion.JOY);
   const { playlists, tokenPending, playlistsPending, playlistsError } =
     useGetAllPlaylistsByQueryQuery(query);
 
@@ -29,19 +29,27 @@ const Music = () => {
       <div className="mb-4">
         <select
           value={query}
-          onChange={(e) => setquery(e.target.value)}
+          onChange={(e) => setQuery(e.target.value as Emotion)}
           className="p-2 border rounded mt-4"
         >
-          <option value={Emotion.JOY}>JOY</option>
-          <option value={Emotion.EXCITED}>EXCITED</option>
-          <option value={Emotion.BUTTERFLY}>BUTTERFLY</option>
-          <option value={Emotion.GRATEFUL}>GRATEFUL</option>
-          <option value={Emotion.CALM}>CALM</option>
-          <option value={Emotion.LONELY}>LONELY</option>
-          <option value={Emotion.ANXIOUS}>ANXIOUS</option>
-          <option value={Emotion.TIRED}>TIRED</option>
-          <option value={Emotion.SAD}>SAD</option>
-          <option value={Emotion.ANGRY}>ANGRY</option>
+          <option value={Emotion.JOY}>{EMOTION_DISPLAY_NAME.JOY}</option>
+          <option value={Emotion.EXCITED}>
+            {EMOTION_DISPLAY_NAME.EXCITED}
+          </option>
+          <option value={Emotion.BUTTERFLY}>
+            {EMOTION_DISPLAY_NAME.BUTTERFLY}
+          </option>
+          <option value={Emotion.GRATEFUL}>
+            {EMOTION_DISPLAY_NAME.GRATEFUL}
+          </option>
+          <option value={Emotion.CALM}>{EMOTION_DISPLAY_NAME.CALM}</option>
+          <option value={Emotion.LONELY}>{EMOTION_DISPLAY_NAME.LONELY}</option>
+          <option value={Emotion.ANXIOUS}>
+            {EMOTION_DISPLAY_NAME.ANXIOUS}
+          </option>
+          <option value={Emotion.TIRED}>{EMOTION_DISPLAY_NAME.TIRED}</option>
+          <option value={Emotion.SAD}>{EMOTION_DISPLAY_NAME.SAD}</option>
+          <option value={Emotion.ANGRY}>{EMOTION_DISPLAY_NAME.ANGRY}</option>
         </select>
       </div>
       <ul>

--- a/src/app/music/type.ts
+++ b/src/app/music/type.ts
@@ -1,25 +1,34 @@
-// AccessToken 응답 타입
+// AccessToken 타입
 export interface SpotifyAccessToken {
-  access_token: string;
+  accessToken: string;
   expiresIn: number;
   success: boolean;
 }
 
-// Spotify 플레이리스트 API 응답 타입
-export type SpotifyPlaylistList = SpotifyPlaylistItem[];
+// Image 타입
+export interface SpotifyImage {
+  url: string;
+}
 
-// 개별 플레이리스트 아이템 타입
+// 플레이리스트 아이템 타입
 export interface SpotifyPlaylistItem {
   id: string;
-  images: SpotifyImage[];
   name: string;
+  external_urls: { spotify: string };
+  images: SpotifyImage[];
   tracks: {
     href: string;
     total: number;
   };
 }
 
-// 이미지 정보 타입
-export interface SpotifyImage {
-  url: string;
+// 플레이리스트 목록 타입
+export type SpotifyPlaylistList = SpotifyPlaylistItem[];
+
+// 컴포넌트 Props 타입
+export interface PlaylistListProps {
+  playlists: SpotifyPlaylistItem[];
+  bookmarkedPlaylistIds: Set<string>;
+  onToggleBookmark: (playlistId: string) => void;
+  isTab: "recommend" | "bookmark";
 }

--- a/src/app/music/type.ts
+++ b/src/app/music/type.ts
@@ -1,6 +1,8 @@
 // AccessToken 응답 타입
 export interface SpotifyAccessToken {
   access_token: string;
+  expiresIn: number;
+  success: boolean;
 }
 
 // Spotify 플레이리스트 API 응답 타입

--- a/src/constants/spotify.constant.ts
+++ b/src/constants/spotify.constant.ts
@@ -20,36 +20,39 @@ export const EMOTIONS: Record<string, string> = {
   ANGRY: "ANGRY",
 };
 
+export const EMOTION_DISPLAY_NAME: Record<keyof typeof Emotion, string> = {
+  JOY: "기쁜 날",
+  EXCITED: "신나는 날",
+  BUTTERFLY: "설레는 날",
+  GRATEFUL: "감사한 날",
+  CALM: "평온한 날",
+  LONELY: "외로운 날",
+  ANXIOUS: "긴장되는",
+  TIRED: "아픈 날",
+  SAD: "슬픈 날",
+  ANGRY: "화나는 날",
+};
+
 export enum Emotion {
-  // Joy "기쁜" – 기쁨, 만족스러운
-  JOY = "happy upbeat energetic joyful content cheerful optimistic",
+  JOY = "happy upbeat energetic joyful content cheerful optimistic 기쁨 즐거움 행복 만족 신바람 유쾌 활기찬",
 
-  // Excited "신나는" – 신이 난
-  EXCITED = "excited lively pumped invigorated exhilarated dynamic",
+  EXCITED = "excited lively pumped invigorated exhilarated dynamic 신남 들뜸 활기찬 열정적인 흥분된 생기있는",
 
-  // Butterfly "설레는" – 흥분, 안달하는
-  BUTTERFLY = "fluttery anticipative nervous jittery excited",
+  BUTTERFLY = "fluttery anticipative nervous jittery excited 설렘 기대 떨림 긴장 두근거림 안달",
 
-  // Grateful "감사한" – 감사하는, 신뢰하는, 자신하는
-  GRATEFUL = "grateful thankful appreciative trusting confident",
+  GRATEFUL = "grateful thankful appreciative trusting confident 감사 고마움 신뢰 자신감 만족",
 
-  // Calm "평온한" – 편안한, 느긋, 안도
-  CALM = "calm serene peaceful relaxed tranquil mellow",
+  CALM = "calm serene peaceful relaxed tranquil mellow 평온 차분함 안도 느긋함 안정 편안함",
 
-  // Lonely "외로운" – 외로운, 고립된, 버려진, 고립된(당황한)
-  LONELY = "lonely isolated abandoned solitary forlorn",
+  LONELY = "lonely isolated abandoned solitary forlorn 외로움 고독 고립 쓸쓸함 버려짐 소외",
 
-  // Anxious "긴장되는" – 초조한, 불안, 걱정스러운, 남의 시선을 의식하는, 당황, 스트레스 받는, 충격 받은, 부끄러운, 혼란스러운(당황한), 혼란스러운, 두려운, 조심스러운, 당혹스러운
-  ANXIOUS = "anxious nervous worried jittery tense uneasy stressed",
+  ANXIOUS = "anxious nervous worried jittery tense uneasy stressed 초조 불안 걱정 긴장 당황 스트레스 충격 부끄러움 혼란 두려움 조심 당혹",
 
-  // Tired "아픈" – 마비된, 취약한
-  TIRED = "tired weary exhausted drained fatigued",
+  TIRED = "tired weary exhausted drained fatigued 피로 지침 탈진 무기력 허약",
 
-  // Sad "슬픈" – 슬픔, 우울한, 좌절한, 눈물이 나는, 낙담한, 괴로워하는, 실망한, 툴툴대는, 상처, 염세적인, 희생된, 환멸을 느끼는, 한심한, 억울한, 배신당한, 비통한, 방어적인, 후회되는, 질투하는, 죄책감의, 가난한 불우한, 회의적인, 열등감
-  SAD = "sad depressed sorrowful melancholic gloomy forlorn tearful",
+  SAD = "sad depressed sorrowful melancholic gloomy forlorn tearful 슬픔 우울 좌절 낙담 실망 괴로움 눈물 상처 염세 희생 환멸 억울 배신 비통 후회 질투 죄책감 가난 회의 열등감",
 
-  // Angry "화나는" – 짜증내는, 노여워하는, 분노, 성가신, 악의적인, 혐오스러운, 구역질 나는
-  ANGRY = "angry furious irate enraged heated upset bitter",
+  ANGRY = "angry furious irate enraged heated upset bitter 화남 분노 짜증 노여움 성가심 악의 혐오 구역질 격분 격노",
 }
 
 // 토큰 만료 기간 (14일)

--- a/src/constants/toast-message.constant.ts
+++ b/src/constants/toast-message.constant.ts
@@ -5,7 +5,11 @@ export const TOAST_MESSAGE = {
     ERROR: "예상치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
     CLIENT_ERROR: "Spotify 자격 증명이 누락되었습니다.",
     ACCESS_TOKEN_ERROR: "액세스 토큰을 가져오는 데 실패했습니다.",
-    PLAYLISTS_ERROR: "선택한 감정에 맞는 플레이리스트가 없습니다.",
+    PLAYLISTS_ERROR: "플레이리스트를 불러오는 데 실패했습니다.",
+    BOOKMARK_ERROR: "추가한 즐겨찾기 플레이리스트가 없습니다.",
+    ADD_BOOKMARK_ERROR: "즐겨찾기에 추가하지 못했습니다. 다시 시도해 주세요.",
+    REMOVE_BOOKMARK_ERROR:
+      "즐겨찾기에서 삭제하지 못했습니다. 다시 시도해 주세요.",
   },
   AI: {
     HUGGINGFACE: {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #4

<br>

## 📝 작업 내용

> 감정 선택 드롭다운을 EmotionSelect 컴포넌트로 분리

> useEffect를 통해 플레이리스트 로딩 실패 시 사용자에게 toast 알림 제공

> 이전 PR 리팩토링입니다.

> 추후 UI 작업할 때, shadcn 적용할 예정입니다.