### PR TITLE
[Refactor/music] Music 페이지 CSS 애니메이션 추가 #135

### DIFF
--- a/src/app/(layout)/main-content-container.tsx
+++ b/src/app/(layout)/main-content-container.tsx
@@ -20,7 +20,7 @@ const MainContentContainer = ({ children }: { children: ReactNode }) => {
           : "bg-white"
       }`}
     >
-      <div className="w-full min-w-[320px] max-w-[984px]"> {children}</div>
+      <div className="w-full min-w-[320px] max-w-[984px]">{children}</div>
     </main>
   );
 };

--- a/src/app/music/_components/emotion-select.tsx
+++ b/src/app/music/_components/emotion-select.tsx
@@ -47,35 +47,36 @@ const EmotionSelect = ({
         </button>
 
         {/* 드롭다운 목록 */}
-        {open && (
-          <div
-            className="absolute top-7 z-50 grid grid-cols-3 gap-4 rounded-bl-2xl rounded-br-2xl rounded-tr-2xl bg-[#ECF3E2E5] px-6 py-4"
-            role="listbox"
-            aria-label="감정 선택 목록"
-          >
-            {emotionKeys.map((key) => {
-              if (emotion === key) return null;
-              const isWhiteOption = key === "SAD" || key === "ANGRY";
+        <div
+          className={`${
+            open ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
+          } absolute top-7 z-50 grid grid-cols-3 gap-4 rounded-bl-2xl rounded-br-2xl rounded-tr-2xl bg-[#ECF3E2E5] px-6 py-4 transition-all duration-200 ease-in-out`}
+          role="listbox"
+          aria-label="감정 선택 목록"
+        >
+          {emotionKeys.map((key) => {
+            if (emotion === key) return null;
+            const isWhiteOption = key === "SAD" || key === "ANGRY";
 
-              return (
-                <button
-                  key={key}
-                  onClick={() => handleSelect(key)}
-                  aria-label={`${EMOTIONS_QUERY[key]} 감정 선택`}
-                  className={`w-[60px] rounded-full border py-[3px] text-center text-sm ${
-                    isWhiteOption ? "text-white" : "text-primary-700"
-                  }`}
-                  style={{
-                    backgroundColor: `var(--color-${EMOTION_COLOR[key]})`,
-                    borderColor: `var(--color-${EMOTION_BORDER_COLOR[key]})`,
-                  }}
-                >
-                  <strong>{EMOTIONS_QUERY[key]}</strong>
-                </button>
-              );
-            })}
-          </div>
-        )}
+            return (
+              <button
+                key={key}
+                onClick={() => handleSelect(key)}
+                aria-label={`${EMOTIONS_QUERY[key]} 감정 선택`}
+                className={`w-[60px] rounded-full border py-[3px] text-center text-sm ${
+                  isWhiteOption ? "text-white" : "text-primary-700"
+                }`}
+                style={{
+                  backgroundColor: `var(--color-${EMOTION_COLOR[key]})`,
+                  borderColor: `var(--color-${EMOTION_BORDER_COLOR[key]})`,
+                }}
+              >
+                <strong>{EMOTIONS_QUERY[key]}</strong>
+              </button>
+            );
+          })}
+        </div>
+        {/* )} */}
 
         <strong className="text-2xl text-white">듣기 좋은</strong>
       </div>

--- a/src/app/music/_components/playlist-card.tsx
+++ b/src/app/music/_components/playlist-card.tsx
@@ -9,7 +9,7 @@ import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { PlaylistCardProps } from "../type";
 
-const PlaylistCard = ({ playlist, userId }: PlaylistCardProps) => {
+const PlaylistCard = ({ playlist, userId, lastCard }: PlaylistCardProps) => {
   const textRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
 
@@ -46,7 +46,9 @@ const PlaylistCard = ({ playlist, userId }: PlaylistCardProps) => {
   };
 
   return (
-    <div className="h-20 border-b border-b-grey-1 last:border-0">
+    <div
+      className={`${lastCard ? "md:border-0" : "border-b border-b-grey-1"} h-20`}
+    >
       <div className="justify-arround my-3 flex items-center gap-2 md:flex-row-reverse">
         <button
           className="flex items-center justify-center"

--- a/src/app/music/_components/playlist-card.tsx
+++ b/src/app/music/_components/playlist-card.tsx
@@ -3,11 +3,24 @@ import {
   useRemoveBookmarkMutation,
 } from "@/hooks/mutations/use-music-bookmarks-mutation";
 import { useGetAllBookmarkedPlaylistsByIdQuery } from "@/hooks/queries/use-get-all-bookmarked-playlists-by-id-query";
+import { motion } from "framer-motion";
 import { Star } from "lucide-react";
 import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 import { PlaylistCardProps } from "../type";
 
 const PlaylistCard = ({ playlist, userId }: PlaylistCardProps) => {
+  const textRef = useRef<HTMLDivElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    if (textRef.current) {
+      const isOverflow =
+        textRef.current.scrollWidth > textRef.current.clientWidth;
+      setIsOverflowing(isOverflow);
+    }
+  }, [playlist.name]);
+
   const musicPlaylistId = playlist.id || playlist.music_playlist_id;
 
   const { mutate: addBookmark } = useAddBookmarkMutation();
@@ -67,7 +80,31 @@ const PlaylistCard = ({ playlist, userId }: PlaylistCardProps) => {
               className="h-full w-full object-cover"
             />
           </div>
-          <strong className="flex-1 truncate text-base">{playlist.name}</strong>
+          <div className="h-6 flex-1 overflow-hidden">
+            <div className="relative" ref={textRef}>
+              {isOverflowing ? (
+                <motion.div
+                  className="absolute left-0 top-0 whitespace-nowrap"
+                  animate={{
+                    x: ["0%", "-33.333%"],
+                    transition: {
+                      ease: "linear",
+                      duration: 10,
+                      repeat: Infinity,
+                    },
+                  }}
+                >
+                  <strong className="px-10">{playlist.name}</strong>
+                  <strong className="px-10">{playlist.name}</strong>
+                  <strong className="px-10">{playlist.name}</strong>
+                </motion.div>
+              ) : (
+                <div className="absolute left-0 top-0 whitespace-nowrap">
+                  <strong>{playlist.name}</strong>
+                </div>
+              )}
+            </div>
+          </div>
           <p className="mr-7 text-xs text-grey-5">{playlist.tracks.total}곡</p>
         </a>
       </div>

--- a/src/app/music/_components/playlist-content.tsx
+++ b/src/app/music/_components/playlist-content.tsx
@@ -3,6 +3,7 @@ import { TOAST_MESSAGE } from "@/constants/toast-message.constant";
 import { useGetAllBookmarkedPlaylistsByIdQuery } from "@/hooks/queries/use-get-all-bookmarked-playlists-by-id-query";
 import { useGetAllPlaylistsByQueryQuery } from "@/hooks/queries/use-get-all-playlists-by-query-query";
 import CookieAlert from "@/ui/common/cookie-alert.common";
+import { motion } from "framer-motion";
 import PlaylistCard from "./playlist-card";
 
 const PlaylistContent = ({
@@ -38,9 +39,33 @@ const PlaylistContent = ({
 
     return (
       <ul className="grid grid-cols-1 gap-x-10 gap-y-3 bg-white px-5 pb-36 md:grid-cols-2">
-        {playlistsData.map((playlist) => (
-          <PlaylistCard key={playlist.id} userId={userId} playlist={playlist} />
-        ))}
+        {playlistsData.map((playlist, index) => {
+          const total = playlistsData.length;
+
+          const isLastCard =
+            total % 2 === 0
+              ? index === total - 1 || index === total - 2
+              : index === total - 1;
+
+          return (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{
+                opacity: 1,
+                y: 0,
+                transition: { delay: index * 0.03 },
+              }}
+              viewport={{ once: true }}
+              key={playlist.id}
+            >
+              <PlaylistCard
+                userId={userId}
+                playlist={playlist}
+                lastCard={isLastCard}
+              />
+            </motion.div>
+          );
+        })}
       </ul>
     );
   }
@@ -60,7 +85,31 @@ const PlaylistContent = ({
       <ul className="grid grid-cols-1 gap-x-10 gap-y-3 bg-white px-5 pb-36 md:grid-cols-2">
         {bookmarkedData?.map((playlist, index) => {
           const key = playlist.id ?? `${playlist.name}-${index}`;
-          return <PlaylistCard key={key} playlist={playlist} userId={userId} />;
+          const total = playlistsData.length;
+
+          const isLastCard =
+            total % 2 === 0
+              ? index === total - 1 || index === total - 2
+              : index === total - 1;
+
+          return (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{
+                opacity: 1,
+                y: 0,
+                transition: { delay: index * 0.04 },
+              }}
+              viewport={{ once: true }}
+              key={key}
+            >
+              <PlaylistCard
+                userId={userId}
+                playlist={playlist}
+                lastCard={isLastCard}
+              />
+            </motion.div>
+          );
         })}
       </ul>
     );

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -7,6 +7,7 @@ import { useGetPostTodayEmotionByIdQuery } from "@/hooks/queries/use-get-posts-t
 import createClient from "@/services/supabase-client-service";
 import CookieAlert from "@/ui/common/cookie-alert.common";
 import Tab from "@/ui/common/tab.common";
+import { motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import EmotionSelect from "./_components/emotion-select";
@@ -109,12 +110,18 @@ const Music = () => {
           style={{ backgroundImage: `url(${imageUrl})` }}
         >
           <div className="absolute inset-0 bg-black/60">
-            <EmotionSelect
-              emotion={emotion}
-              onChange={setEmotion}
-              todayEmotion={todayEmotionData?.[0]?.post_emotion}
-              scrolled={isScrolled}
-            />
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <EmotionSelect
+                emotion={emotion}
+                onChange={setEmotion}
+                todayEmotion={todayEmotionData?.[0]?.post_emotion}
+                scrolled={isScrolled}
+              />
+            </motion.div>
           </div>
         </div>
       </section>

--- a/src/app/music/type.ts
+++ b/src/app/music/type.ts
@@ -35,6 +35,7 @@ export enum PlaylistTabProps {
 export interface PlaylistCardProps {
   playlist: SpotifyPlaylistItem;
   userId: string;
+  lastCard: boolean;
 }
 
 export type BookmarkedProps = {

--- a/src/app/music/type.ts
+++ b/src/app/music/type.ts
@@ -27,11 +27,6 @@ export interface EmotionSelectProps {
   scrolled: boolean;
 }
 
-export enum PlaylistTabProps {
-  RECOMMEND = "추천 플리",
-  BOOKMARK = "즐겨찾기",
-}
-
 export interface PlaylistCardProps {
   playlist: SpotifyPlaylistItem;
   userId: string;

--- a/src/ui/common/tab.common.tsx
+++ b/src/ui/common/tab.common.tsx
@@ -1,5 +1,3 @@
-import { motion } from "framer-motion";
-
 const Tab = ({
   firstTab,
   secondTab,
@@ -22,20 +20,20 @@ const Tab = ({
         <button
           key={tab.id}
           onClick={() => setActiveTab(tab.id)}
-          className={`relative px-3 pb-[6px] ${tab.id === activeTab ? "text-primary-600" : "text-grey-3"}`}
+          className={`relative px-3 pb-[6px] ${
+            tab.id === activeTab ? "text-primary-600" : "text-grey-3"
+          }`}
           style={{
             WebkitTapHighlightColor: "transparent",
           }}
         >
           <strong>
             {tab.label}
-            {activeTab === tab.id && (
-              <motion.div
-                layoutId="underline"
-                className="absolute -bottom-0 left-0 right-0 h-[2px] bg-primary-600"
-                transition={{ type: "spring", stiffness: 300, damping: 30 }}
-              />
-            )}
+            <span
+              className={`absolute bottom-0 left-0 right-0 h-[2px] bg-primary-600 transition-all duration-300 ease-in-out ${
+                tab.id === activeTab ? "scale-x-100" : "scale-x-0"
+              }`}
+            />
           </strong>
         </button>
       ))}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #135

<br>

## 📝 작업 내용

> 플레이리스트 커버 이미지 및 텍스트 영역 애니메이션 추가
> Select 감정 선택 드롭다운 애니메이션 추가
> 플레이리스트 카드 애니메이션 추가
> 플레이리스트 제목 무한 스크롤 애니메이션 추가

> 공통 Tab 컴포넌트 애니메이션 수정 (motion.div 제거)

<br>

## 💬 리뷰 요구사항

> 플레이리스트 카드 컴포넌트 : last:border-0 부분 재수정 필요합니다.
> Music 페이지 : 스크롤 위치 재수정 필요합니다.